### PR TITLE
Allow named containers of relevant info

### DIFF
--- a/src/Contextually/InfoBlock.cs
+++ b/src/Contextually/InfoBlock.cs
@@ -16,22 +16,40 @@ namespace Contextually
         /// </summary>
         /// <param name="parent">Optional parent block.</param>
         /// <param name="info">Required values for this block.</param>
-        internal InfoBlock(InfoBlock parent, NameValueCollection info)
+        internal InfoBlock(RelevantInfoContainer container, NameValueCollection info)
         {
-            ParentBlock = parent;
+            ParentBlock = null;
+
+            Container = container;
 
             CurrentInfo = new NameValueCollection(info);
         }
 
         /// <summary>
+        /// Create a new Info block with new values and potentially a parent block.
+        /// </summary>
+        /// <param name="parent">Optional parent block.</param>
+        /// <param name="info">Required values for this block.</param>
+        internal InfoBlock(InfoBlock parent, NameValueCollection info)
+        {
+            ParentBlock = parent;
+
+            Container = parent.Container;
+
+            CurrentInfo = new NameValueCollection(info);
+        }
+
+        internal RelevantInfoContainer Container { get; }
+
+        /// <summary>
         /// A reference to the parent enclosing Info block.
         /// </summary>
-        internal InfoBlock ParentBlock { get; private set; }
+        internal InfoBlock ParentBlock { get; }
 
         /// <summary>
         /// The values assigned in the nearest enclosing Info block.
         /// </summary>
-        internal NameValueCollection CurrentInfo { get; private set; }
+        internal NameValueCollection CurrentInfo { get; }
 
         /// <summary>
         /// Disposes of the context and sets the active context to the parent, if any.
@@ -45,10 +63,10 @@ namespace Contextually
                 throw new ObjectDisposedException(nameof(InfoBlock), 
                     "This Info block was already disposed, and you should already know that.");
 
-            if (Relevant.Head.Value == this)
+            if (Container.Head.Value == this)
             {
                 // Set the head of the context linked-list to the parent of this.
-                Relevant.Head.Value = ParentBlock;
+                Container.Head.Value = ParentBlock;
 
                 IsDisposed = true;
             }

--- a/test/Contextually.Tests/SynchronyousTests.cs
+++ b/test/Contextually.Tests/SynchronyousTests.cs
@@ -8,6 +8,143 @@ namespace Contextually.Tests
     public class SynchronyousTests
     {
         [TestMethod]
+        public void AccessingNamedInfoWithoutABlockReturnsEmptyCollection()
+        {
+            // ARRANGE
+
+            // ACT
+            var info = Relevant.Info("test");
+
+            // ASSERT
+            Assert.IsNotNull(info, "should have a value");
+            Assert.IsInstanceOfType(info, typeof(NameValueCollection), "should be a NameValueCollection");
+            Assert.AreEqual(0, info.Count, "should have no pairs");
+        }
+
+        [TestMethod]
+        public void AccessingNamedInfoWithinASingleBlockReturnsExpectedValues()
+        {
+            // ARRANGE
+            var expectedValues = new NameValueCollection
+            {
+                ["Key1"] = "Value1"
+            };
+
+            NameValueCollection actualValues;
+
+            // ACT
+            using (Relevant.Info(expectedValues, "test"))
+            {
+                actualValues = Relevant.Info("test");
+            }
+
+            // ASSERT
+            Assert.IsNotNull(actualValues, "should have a value");
+            Assert.IsInstanceOfType(actualValues, typeof(NameValueCollection), "should be a NameValueCollection");
+            Assert.AreEqual(expectedValues.Count, actualValues.Count, $"should have {expectedValues.Count} pair");
+            Assert.AreEqual(expectedValues["Key1"], actualValues["Key1"], "should have same value");
+        }
+
+                [TestMethod]
+        public void AccessingNamedInfoWithinNestedBlocksReturnsExpectedValues()
+        {
+            // ARRANGE
+            var expectedValuesLevelOne = new NameValueCollection
+            {
+                ["Key1"] = "Value1"
+            };
+
+            var expectedValuesLevelTwo = new NameValueCollection
+            {
+                ["Key1"] = "Value1",
+                ["Key2"] = "Value2"
+            };
+
+            var valuesLevelTwo = new NameValueCollection
+            {
+                ["Key2"] = "Value2"
+            };
+
+            NameValueCollection actualValuesLevelOne;
+            NameValueCollection actualValuesLevelTwo;
+
+            // ACT
+            using (Relevant.Info(expectedValuesLevelOne, "test"))
+            {
+                actualValuesLevelOne = Relevant.Info("test");
+
+                using (Relevant.Info(valuesLevelTwo, "test"))
+                {
+                    actualValuesLevelTwo = Relevant.Info("test");
+                }
+            }
+
+            // ASSERT
+            Assert.IsNotNull(actualValuesLevelOne, "should have a value");
+            Assert.IsInstanceOfType(actualValuesLevelOne, typeof(NameValueCollection), "should be a NameValueCollection");
+            Assert.AreEqual(expectedValuesLevelOne.Count, actualValuesLevelOne.Count, $"should have {expectedValuesLevelOne.Count} pair");
+            Assert.AreEqual(expectedValuesLevelOne["Key1"], actualValuesLevelOne["Key1"], "should have same value");
+
+            Assert.IsNotNull(actualValuesLevelTwo, "should have a value");
+            Assert.IsInstanceOfType(actualValuesLevelTwo, typeof(NameValueCollection), "should be a NameValueCollection");
+            Assert.AreEqual(expectedValuesLevelTwo.Count, actualValuesLevelTwo.Count, $"should have {expectedValuesLevelTwo.Count} pair");
+            Assert.AreEqual(expectedValuesLevelTwo["Key1"], actualValuesLevelTwo["Key1"], "should have same value");
+            Assert.AreEqual(expectedValuesLevelTwo["Key2"], actualValuesLevelTwo["Key2"], "should have same value");
+        }
+
+        public void AccessingNamedInfoWithinDifferentNestedBlocksReturnsExpectedValues()
+        {
+            // ARRANGE
+            var expectedValuesLevelOne = new NameValueCollection
+            {
+                ["Key1"] = "Value1"
+            };
+
+            var expectedValuesLevelTwo = new NameValueCollection
+            {
+                ["Key1"] = "Value1",
+                ["Key2"] = "Value2"
+            };
+
+            var valuesLevelTwo = new NameValueCollection
+            {
+                ["Key2"] = "Value2"
+            };
+
+            NameValueCollection actualValuesLevelOne;
+            NameValueCollection actualValuesLevelTwo;
+            NameValueCollection actualValuesLevelOneInner;
+
+            // ACT
+            using (Relevant.Info(expectedValuesLevelOne))
+            {
+                actualValuesLevelOne = Relevant.Info();
+
+                using (Relevant.Info(valuesLevelTwo, "test"))
+                {
+                    actualValuesLevelTwo = Relevant.Info("test");
+                    actualValuesLevelOneInner = Relevant.Info();
+                }
+            }
+
+            // ASSERT
+            Assert.IsNotNull(actualValuesLevelOne, "should have a value");
+            Assert.IsInstanceOfType(actualValuesLevelOne, typeof(NameValueCollection), "should be a NameValueCollection");
+            Assert.AreEqual(expectedValuesLevelOne.Count, actualValuesLevelOne.Count, $"should have {expectedValuesLevelOne.Count} pair");
+            Assert.AreEqual(expectedValuesLevelOne["Key1"], actualValuesLevelOne["Key1"], "should have same value");
+
+            Assert.IsNotNull(actualValuesLevelTwo, "should have a value");
+            Assert.IsInstanceOfType(actualValuesLevelTwo, typeof(NameValueCollection), "should be a NameValueCollection");
+            Assert.AreEqual(valuesLevelTwo.Count, actualValuesLevelTwo.Count, $"should have {valuesLevelTwo.Count} pair");
+            Assert.AreEqual(valuesLevelTwo["Key2"], actualValuesLevelTwo["Key2"], "should have same value");
+
+            Assert.IsNotNull(actualValuesLevelOne, "should have a value");
+            Assert.IsInstanceOfType(actualValuesLevelOneInner, typeof(NameValueCollection), "should be a NameValueCollection");
+            Assert.AreEqual(expectedValuesLevelOne.Count, actualValuesLevelOneInner.Count, $"should have {expectedValuesLevelOne.Count} pair");
+            Assert.AreEqual(expectedValuesLevelOne["Key1"], actualValuesLevelOneInner["Key1"], "should have same value");
+        }
+
+        [TestMethod]
         public void AccessingInfoWithoutABlockReturnsEmptyCollection()
         {
             // ARRANGE


### PR DESCRIPTION
#1 @tyrotoxin

Allows named containers for the static class, but also allows for RelevantInfoContainers to be instantiated and kept in private or internal scoping outside of the static class.