### PR TITLE
Updated Contextually to support netstandard2.1, netcoreapp3.1, and .net 5.0

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,16 +1,21 @@
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
     "command": "dotnet",
-    "isShellCommand": true,
     "args": [],
     "tasks": [
         {
-            "taskName": "build",
+            "label": "build",
+            "type": "shell",
+            "command": "dotnet",
             "args": [
+                "build",
                 "${workspaceRoot}\\src\\Examples\\NTier\\NTier.csproj"
             ],
-            "isBuildCommand": true,
-            "problemMatcher": "$msCompile"
+            "problemMatcher": "$msCompile",
+            "group": {
+                "_id": "build",
+                "isDefault": false
+            }
         }
     ]
 }

--- a/.vscode/tasks.json.old
+++ b/.vscode/tasks.json.old
@@ -1,0 +1,16 @@
+{
+    "version": "0.1.0",
+    "command": "dotnet",
+    "isShellCommand": true,
+    "args": [],
+    "tasks": [
+        {
+            "taskName": "build",
+            "args": [
+                "${workspaceRoot}\\src\\Examples\\NTier\\NTier.csproj"
+            ],
+            "isBuildCommand": true,
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/Contextually/Contextually.csproj
+++ b/src/Contextually/Contextually.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net452;net46</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netstandard2.1;netstandard2.0;netstandard1.3;net452;net46</TargetFrameworks>
     <AssemblyVersion>1.4.0.0</AssemblyVersion>
     <FileVersion>1.4.0.0</FileVersion>
     <Version>1.4.0</Version>
     <Company>Psibernetic Solutions, LLC</Company>
     <Description />
-    <Authors>Ovan Crone, Andrea Balfour, Sergii Semenov</Authors>
-    <Copyright>Psibernetic Solutions, LLC 2017</Copyright>
+    <Authors>Aida Crone, Andrea Balfour, Sergii Semenov</Authors>
+    <Copyright>Psibernetic Solutions, LLC 2017-2021</Copyright>
     <PackageProjectUrl>https://github.com/psibr/Contextually</PackageProjectUrl>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/psibr/Contextually</RepositoryUrl>

--- a/src/Contextually/Contextually.csproj
+++ b/src/Contextually/Contextually.csproj
@@ -6,7 +6,7 @@
     <Version>1.5.0</Version>
     <Company>Psibernetic Solutions, LLC</Company>
     <Description />
-    <Authors>Aida Crone, Andrea Balfour, Sergii Semenov</Authors>
+    <Authors>Aida Crone, Adrian Balfour, Sergii Semenov</Authors>
     <Copyright>Psibernetic Solutions, LLC 2017-2021</Copyright>
     <PackageProjectUrl>https://github.com/psibr/Contextually</PackageProjectUrl>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>

--- a/src/Contextually/Contextually.csproj
+++ b/src/Contextually/Contextually.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net5.0;netcoreapp3.1;netstandard2.1;netstandard2.0;netstandard1.3;net452;net46</TargetFrameworks>
-    <AssemblyVersion>1.4.0.0</AssemblyVersion>
-    <FileVersion>1.4.0.0</FileVersion>
-    <Version>1.4.0</Version>
+    <AssemblyVersion>1.5.0.0</AssemblyVersion>
+    <FileVersion>1.5.0.0</FileVersion>
+    <Version>1.5.0</Version>
     <Company>Psibernetic Solutions, LLC</Company>
     <Description />
     <Authors>Aida Crone, Andrea Balfour, Sergii Semenov</Authors>

--- a/test/Contextually.Tests.FullFramework/Contextually.Tests.FullFramework.csproj
+++ b/test/Contextually.Tests.FullFramework/Contextually.Tests.FullFramework.csproj
@@ -41,18 +41,19 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      
-<HintPath>..\..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      
-<HintPath>..\..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Specialized, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Specialized.4.0.1\lib\net46\System.Collections.Specialized.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Contextually.Tests\AsynchronyousAndThreadedTests.cs">

--- a/test/Contextually.Tests.FullFramework/packages.config
+++ b/test/Contextually.Tests.FullFramework/packages.config
@@ -3,4 +3,5 @@
   <package id="MSTest.TestAdapter" version="1.1.18" targetFramework="net452" />
   <package id="MSTest.TestFramework" version="1.1.18" targetFramework="net452" />
   <package id="System.Collections.Specialized" version="4.0.1" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
 </packages>

--- a/test/Contextually.Tests.Net45/Contextually.Tests.Net45.csproj
+++ b/test/Contextually.Tests.Net45/Contextually.Tests.Net45.csproj
@@ -46,6 +46,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Contextually.Tests\AsynchronyousAndThreadedTests.cs">

--- a/test/Contextually.Tests.Net45/packages.config
+++ b/test/Contextually.Tests.Net45/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="MSTest.TestAdapter" version="1.1.18" targetFramework="net452" />
   <package id="MSTest.TestFramework" version="1.1.18" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net452" />
 </packages>

--- a/test/Contextually.Tests/Contextually.Tests.csproj
+++ b/test/Contextually.Tests/Contextually.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netstandard2.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
-Updated Contextually to support netstandard2.1, netcoreapp3.1, and .net 5.0
-Updated outdated authorship info and copyright
-Added multi-target support to Contextually.Tests